### PR TITLE
Show max SoG location on voyage

### DIFF
--- a/parse_logbook.js
+++ b/parse_logbook.js
@@ -59,10 +59,11 @@ function groupVoyages(entries) {
     const entryDate = new Date(entry.datetime.getFullYear(), entry.datetime.getMonth(), entry.datetime.getDate());
 
     if (!current) {
-      current = { 
+      current = {
         startTime: entry.datetime,
         endTime: entry.datetime,
         distance: 0, maxSpeed: 0, maxWind: 0,
+        maxSpeedCoord: null,
         coords: [],
         windHeadings: [],
         windSpeedSum: 0,
@@ -83,12 +84,14 @@ function groupVoyages(entries) {
           maxWind:   current.maxWind,
           avgWindSpeed: avgWindSpeed,
           avgWindHeading: current.windHeadings.length > 0 ? circularMean(current.windHeadings) : null,
-          coords:    current.coords
+          coords:    current.coords,
+          maxSpeedCoord: current.maxSpeedCoord
         });
-        current = { 
+        current = {
           startTime: entry.datetime,
           endTime: entry.datetime,
           distance: 0, maxSpeed: 0, maxWind: 0,
+          maxSpeedCoord: null,
           coords: [],
           windHeadings: [],
           windSpeedSum: 0,
@@ -101,9 +104,10 @@ function groupVoyages(entries) {
 
     current.endTime = entry.datetime;
 
+    let coord = null;
     if (entry.position && typeof entry.position.longitude === 'number' &&
         typeof entry.position.latitude === 'number') {
-      const coord = [entry.position.longitude, entry.position.latitude];
+      coord = [entry.position.longitude, entry.position.latitude];
       if (current.coords.length > 0) {
         current.distance += haversine(current.coords[current.coords.length-1], coord);
       }
@@ -112,7 +116,10 @@ function groupVoyages(entries) {
     if (entry.speed) {
       const s = entry.speed.sog ?? entry.speed.stw;
       if (typeof s === 'number') {
-        if (s > current.maxSpeed) current.maxSpeed = s;
+        if (s > current.maxSpeed) {
+          current.maxSpeed = s;
+          if (coord) current.maxSpeedCoord = coord;
+        }
         current.speedSum += s;
         current.speedCount++;
       }
@@ -141,7 +148,8 @@ function groupVoyages(entries) {
       maxWind:   current.maxWind,
       avgWindSpeed: avgWindSpeed,
       avgWindHeading: current.windHeadings.length > 0 ? circularMean(current.windHeadings) : null,
-      coords:    current.coords
+      coords:    current.coords,
+      maxSpeedCoord: current.maxSpeedCoord
     });
   }
   return voyages;

--- a/public/index.html
+++ b/public/index.html
@@ -99,7 +99,7 @@ document.getElementById('regenBtn').addEventListener('click', () => {
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 
 <script>
-let map, polylines = [];
+let map, polylines = [], maxMarker;
 
 async function load() {
   // fetch the data
@@ -112,6 +112,7 @@ async function load() {
     map.remove();    // safely destroy the Leaflet map instance
   }
   polylines = [];
+  maxMarker = null;
 
   map = L.map('map').setView([0, 0], 2);
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
@@ -148,6 +149,16 @@ async function load() {
       line.setStyle({ color: 'red', weight: 4 });
       // fit map bounds to selected line
       map.fitBounds(line.getBounds());
+      // remove existing marker
+      if (maxMarker) {
+        map.removeLayer(maxMarker);
+        maxMarker = null;
+      }
+      if (v.maxSpeedCoord && v.maxSpeedCoord.length === 2) {
+        const [lon, lat] = v.maxSpeedCoord;
+        maxMarker = L.circleMarker([lat, lon], { color: 'orange', radius: 6 }).addTo(map);
+        maxMarker.bindPopup(`Max SoG: ${v.maxSpeed.toFixed(1)} kn`).openPopup();
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- record coordinates where maximum speed occurs when generating voyages
- highlight selected voyage and mark where max SoG was reached

## Testing
- `node parse_logbook.js .`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ef1b8a0588331a9b9362d55ff3446