### PR TITLE
Enforce 24-hour voyage separation

### DIFF
--- a/LOG.md
+++ b/LOG.md
@@ -81,3 +81,4 @@
 - Lowered dark-mode Voyager tile brightness further and increased contrast more so the basemap stays legible without overpowering the darker UI.
 - Guard voyage max-speed and max-wind calculations by excluding log entries without coordinates so instrument glitches (e.g., 46 kt SOG with no position) cannot distort voyage summaries.
 - Group voyages by UTC day boundaries to avoid splitting a single journey across multiple voyages when entries occur near local midnight in different timezones.
+- Revert voyage grouping to a strict 24-hour gap so voyages separated by more than a day (e.g., July 1 vs. July 4) are treated as distinct trips.

--- a/parse_logbook.js
+++ b/parse_logbook.js
@@ -511,10 +511,18 @@ function groupVoyages(entries) {
   let current = null;
   let lastDate = null;
 
+  /**
+   * Function: isConsecutiveDay
+   * Description: Determine whether two UTC-normalised dates fall within the same or next calendar day.
+   * Parameters:
+   *   d1 (Date): Reference date for the prior log entry.
+   *   d2 (Date): Date of the current log entry.
+   * Returns: boolean - True when the entries should be grouped into the same voyage.
+   */
   function isConsecutiveDay(d1, d2) {
-    const oneDay = 48 * 60 * 60 * 1000;
+    const ONE_DAY_MS = 24 * 60 * 60 * 1000;
     const diff = d2.getTime() - d1.getTime();
-    return diff >= 0 && diff <= oneDay;
+    return diff >= 0 && diff <= ONE_DAY_MS;
   }
 
   for (const entry of entries) {


### PR DESCRIPTION
## Summary
- restore voyage grouping to require entries within 24 hours to remain in the same voyage
- document the stricter grouping threshold in the project log

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69378a13cd788331a209c397562c6500)